### PR TITLE
add get and count methods on both engines

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -79,3 +79,40 @@ class DBStorage:
     def close(self):
         """call remove() method on the private session attribute"""
         self.__session.remove()
+
+    def get(self, cls, id):
+        """gets and returns a single key and value object whose id
+        and class name are given
+
+        Args:
+            cls - class name of the object to be obtained and returned
+            id - id attribute of the object to be obtained and returned
+
+        Return:
+            the object, if found, otherwise None is returned
+        """
+        obj = {}
+        if (cls in classes.values()):
+            key = "{}.{}".format(str(cls).split('.')[1].title(), id)
+            for an_obj_key in self.all(cls):
+                if (an_obj_key == key):
+                    obj[key] = self.all(cls)[an_obj_key]
+                    break
+        else:
+            return None
+        return obj
+
+    def count(self, cls=None):
+        """counts the total number of instances of the given class
+
+        Args:
+            cls - a class of the instances that are counted
+        """
+        counter = 0
+        if (cls in classes.values()):
+            for obj_k in self.all(cls):
+                counter += 1
+        else:
+            for obj_k in self.all():
+                counter += 1
+        return counter

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -68,3 +68,40 @@ class FileStorage:
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()
+
+    def get(self, cls, id):
+        """gets an one or single object whose id and class are given
+
+        Args:
+            cls - the class name of the object to be returned
+            id - the value of the id's attribute of the object
+        Return:
+            the found object must be returned
+        """
+        obj = {}
+        if cls in classes.values():
+            key = "{}.{}".format(str(cls).split('.')[1].title(), id)
+            if (key in self.all()):
+                for an_obj_key in self.all(cls):
+                    if (an_obj_key == key):
+                        obj[key] = self.all(cls)[an_obj_key]
+                        return obj
+            else:
+                return None
+        else:
+            return None
+
+    def count(self, cls=None):
+        """counts the total number of instances of the given class
+
+        Args:
+            cls - a class of the instances that are counted
+        """
+        counter = 0
+        if (cls in classes.values()):
+            for obj_k in self.all(cls):
+                counter += 1
+        else:
+            for obj_k in self.all():
+                counter += 1
+        return counter

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -143,3 +143,39 @@ class TestFileStorage(unittest.TestCase):
         models.storage.save()
         st_obj_from_db = models.storage.all(State)[st_key]
         self.assertTrue(st.name == st_obj_from_db.name)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_get(self):
+        """Test that get method obtains a correct object"""
+        st = State(name='Lagos')
+        st.save()
+        ct = City(name='Ketu', state_id=st.id)
+        ct.save()
+        st_instance_obj = ct_instance_obj = None
+        for obj_k in models.storage.get(State, st.id):
+            st_instance_obj = models.storage.get(State, st.id)[obj_k]
+        for obj_k in models.storage.get(City, ct.id):
+            ct_instance_obj = models.storage.get(City, ct.id)[obj_k]
+        self.assertTrue(st_instance_obj.id == st.id)
+        self.assertTrue(ct_instance_obj.id == ct.id)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing file storage")
+    def test_count(self):
+        """Test that count works correctly"""
+        state_list = ['Lagos', 'Abuja', 'Kwara']
+        st_inst_list = []
+        for i in range(3):
+            st = State(name=state_list[i])
+            st.save()
+            st_inst_list.append(st)
+        city_list = ['Ketu', 'Gwagwalada', 'Asa']
+        ct_inst_list = []
+        for i in range(3):
+            ct = City(name=city_list[i],
+                      state_id=st_inst_list[i].id)
+            ct.save()
+        num_state = models.storage.count(State)
+        num_city = models.storage.count(City)
+        num_all = models.storage.count()
+        self.assertTrue(num_all > num_state)
+        self.assertTrue(num_all > num_city)

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -114,3 +114,45 @@ class TestFileStorage(unittest.TestCase):
         with open("file.json", "r") as f:
             js = f.read()
         self.assertEqual(json.loads(string), json.loads(js))
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_get(self):
+        """Test that get actually obtains the correct object"""
+        storage = FileStorage()
+        st = State(name='Lagos')
+        st.save()
+        ct = City(name='Ikeja', state_id=st.id)
+        ct.save()
+        st_instance_from_store = storage.get(State, st.id)
+        st_instance_obj = None
+        for obj_key in st_instance_from_store:
+            st_instance_obj = st_instance_from_store[obj_key]
+        self.assertTrue(st.id == st_instance_obj.id)
+        ct_instance_from_store = storage.get(City, ct.id)
+        ct_instance_obj = None
+        for obj_key in ct_instance_from_store:
+            ct_instance_obj = ct_instance_from_store[obj_key]
+        self.assertTrue(ct.id == ct_instance_obj.id)
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_count(self):
+        """Test that count works correctly"""
+        storage = FileStorage()
+        state_list = ['Lagos', 'Abuja', 'Kwara']
+        st_inst_list = []
+        for i in range(3):
+            st = State(name=state_list[i])
+            st.save()
+            st_inst_list.append(st)
+        city_list = ['Ketu', 'Gwagwalada', 'Asa']
+        ct_inst_list = []
+        for i in range(3):
+            ct = City(name=city_list[i],
+                      state_id=st_inst_list[i].id)
+            ct.save()
+        num_state = storage.count(State)
+        num_city = storage.count(City)
+        num_all = storage.count()
+        self.assertTrue(num_state == num_city)
+        self.assertTrue(num_all > num_state)
+        self.assertTrue(num_all > num_city)


### PR DESCRIPTION
Add the following methods:

- **count**, which takes a class name, whose instances are to be counted, and the total number of it, is returned.
- **get**, which takes, both the class name and an id of an instance and returns the instance from either of the two storage engines, depending on the one in use.